### PR TITLE
Set provider to false

### DIFF
--- a/app/pixi.html
+++ b/app/pixi.html
@@ -176,7 +176,7 @@
 	<script>
 		var app = angular.module('pixi',['ngSanitize', 'ngFileUpload', 'infinite-scroll', 'ngMaterial', 'angularMoment' ]).
 		config(function($sceProvider) {
-			$sceProvider.enabled(true)
+			$sceProvider.enabled(false)
 		}).
 		controller('pixiController', function($scope, $http, $sce, Upload){
 


### PR DESCRIPTION
This change modifies the provider to set it to false.  This change makes it much easier to test out accessing the API as it disables a security control.